### PR TITLE
Add required CanvasRenderer (Unity 2020.X)

### DIFF
--- a/Scripts/MenuController.cs
+++ b/Scripts/MenuController.cs
@@ -105,6 +105,7 @@ namespace WeersProductions
             outsideMenuRect.anchorMin = Vector2.zero;
             outsideMenuRect.anchorMax = Vector2.one;
             outsideMenuGameObject.SetActive(false);
+            outsideMenuGameObject.AddComponent<CanvasRenderer>();
             return outsideMenuGameObject.AddComponent<NonDrawingGraphic>();
         }
 


### PR DESCRIPTION
Related to this: https://forum.unity.com/threads/no-canvasrenderer-attached-to-the-caret-game-object.943068/